### PR TITLE
Fix NullPointerException when response is empty

### DIFF
--- a/rfc3986-uri/src/main/java/org/dmfs/rfc3986/encoding/FormEncoded.java
+++ b/rfc3986-uri/src/main/java/org/dmfs/rfc3986/encoding/FormEncoded.java
@@ -137,7 +137,7 @@ public final class FormEncoded implements UriEncoded
 
     private CharSequence encoded(CharSequence charSequence, String charSet) throws UnsupportedEncodingException
     {
-        final int len = charSequence.length();
+        final int len = charSequence != null ? charSequence.length() : 0;
         if (len == 0)
         {
             return IdempotentEncoded.EMPTY;


### PR DESCRIPTION
Fixes the issue reported here: https://github.com/dmfs/oauth2-essentials/issues/78